### PR TITLE
Always include a copyright notice in 'LicenseWithSummary::summary_or_text'

### DIFF
--- a/lib/Software/LicenseMoreUtils/LicenseWithSummary.pm
+++ b/lib/Software/LicenseMoreUtils/LicenseWithSummary.pm
@@ -71,12 +71,14 @@ sub license_class {
 sub debian_text {
     my $self = shift;
     carp "debian_text is deprecated, please use summary_or_text";
-    return $self->summary || $self->fulltext;
+    return $self->summary_or_text;
 }
 
 sub summary_or_text {
     my $self = shift;
-    return $self->summary || $self->fulltext;
+    return join("\n", $self->notice, $self->summary)
+        if length $self->summary;
+    return $self->fulltext;
 }
 
 sub AUTOLOAD {


### PR DESCRIPTION
Hi,

The routine `LicenseWithSummary::summary` produces only a license summary, while `Software::License::fulltext` produces a copyright notice in addition to the full text:

```
#pod =method fulltext
#pod
#pod This method returns the complete text of the license, preceded by
the copyright
#pod notice.
#pod
#pod =cut

sub fulltext {
  my ($self) = @_;
  return join "\n", $self->notice, $self->license;
}
```

The asymmetry causes a problem in `LicenseWithSummary::summary_or_text` as used in `license-reconcile`.

This pull request always includes a copyright notice as part of `LicenseWithSummary::summary_or_text` so the method is better usable in `license-reconcile`.

For more information, please check out Debian bugs [#911403](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=911403) and [#905614](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=905614). Thank you!

Kind regards,
Felix Lechner
